### PR TITLE
Fix error in contin-lists

### DIFF
--- a/prefix_tree.asv
+++ b/prefix_tree.asv
@@ -15,6 +15,7 @@ classdef Prefix_tree < handle
 
             prefix = [];
             overall = length(obj.training_input);
+            obj.training_input = [obj.training_input, midi_input];
 
             if size(midi_input,2) > size(midi_input,1)
                 midi_input = midi_input';
@@ -43,14 +44,16 @@ classdef Prefix_tree < handle
         
         function [obj] = add_input(obj, root_input)
             
-            node_list = [];
+            node_list = Node.empty;
             cur_nodes = obj.root_nodes;
             cur_input = root_input;
             i = 0;
+            hit_loop = false;
             
             while cur_input.has_children
                 
                 i = i + 1;
+                hit_loop = true;
                 
                 % if tree has no further nodes, add remaining input
                 if isempty(cur_nodes)
@@ -76,7 +79,6 @@ classdef Prefix_tree < handle
                             node_list(end).add_child(cur_input);
                         else
                             obj.root_nodes = [obj.root_nodes, cur_input];
-                            % cur_nodes instead of obj.root_nodes?
                         end
                     end
                 end
@@ -84,28 +86,23 @@ classdef Prefix_tree < handle
                 cur_input = cur_input.children(1);
             end
             
-            % handle case for cur_input has no children
-            % while loop above ends with cur_input as the last child
-            for j = 1:length(cur_nodes)
-                    
-                if cur_nodes(j).is_equal(cur_input)
-                    node_list(i) = cur_nodes(j);
-                    cur_nodes = cur_nodes(j).children;
-                        % mysteriously adding extra root node on 2nd iter,
-                        % causing a type mismatch at line 98,
-                        % because node_list is uninitialized!
-                        % find reason for phantom root node
-                    break;                        
-                end
+            % handle case for root_input had no children
+            if ~hit_loop
+                i = 1;
+                for j = 1:length(cur_nodes)
 
-                if j == length(cur_nodes)
-                    % add rest of input as chain of nodes
-                    if ~isempty(node_list)
-                        node_list(end).add_child(cur_input);
-                    else
-                        obj.root_nodes = [obj.root_nodes, cur_input];
-                        % 2nd iter is hitting this line, and adding
-                        % the last child of input as a new root node here
+                    if cur_nodes(j).is_equal(cur_input)
+                        node_list(i) = cur_nodes(j);
+                        break;                        
+                    end
+
+                    if j == length(cur_nodes)
+                        % add rest of input as chain of nodes
+                        if ~isempty(node_list)
+                            node_list(end).add_child(cur_input);
+                        else
+                            obj.root_nodes = [obj.root_nodes, cur_input];
+                        end
                     end
                 end
             end

--- a/prefix_tree.m
+++ b/prefix_tree.m
@@ -1,5 +1,5 @@
 classdef Prefix_tree < handle
-    
+     
     properties
         
         root_nodes = [];
@@ -10,7 +10,6 @@ classdef Prefix_tree < handle
     methods
     
         % get prefixes from input
-        
         function [obj] = parse(obj, midi_input)
 
             prefix = [];
@@ -41,20 +40,16 @@ classdef Prefix_tree < handle
         end
         
         % add input to tree
-        
         function [obj] = add_input(obj, root_input)
             
             node_list = Node.empty;
             cur_nodes = obj.root_nodes;
             cur_input = root_input;
             i = 0;
-            hit_loop = false;
             
-            while cur_input.has_children
-                
+            while ~isempty(cur_input)
                 i = i + 1;
-                hit_loop = true;
-                
+                 
                 % if tree has no further nodes, add remaining input
                 if isempty(cur_nodes)
                    if ~isempty(node_list)
@@ -70,6 +65,12 @@ classdef Prefix_tree < handle
                     if cur_nodes(j).is_equal(cur_input)
                         node_list(i) = cur_nodes(j);
                         cur_nodes = cur_nodes(j).children;
+                        
+                        if ~isempty(cur_input.children)
+                            cur_input = cur_input.children(1);
+                        else
+                            cur_input = Node.empty;
+                        end
                         break;
                     end
                    
@@ -80,40 +81,95 @@ classdef Prefix_tree < handle
                         else
                             obj.root_nodes = [obj.root_nodes, cur_input];
                         end
-                    end
-                end
-                
-                cur_input = cur_input.children(1);
-            end
-            
-            % handle case for root_input had no children
-            if ~hit_loop
-                i = 1;
-                for j = 1:length(cur_nodes)
-
-                    if cur_nodes(j).is_equal(cur_input)
-                        node_list(i) = cur_nodes(j);
-                        cur_nodes = cur_nodes(j).children;
-                        break;                        
-                    end
-
-                    if j == length(cur_nodes)
-                        % add rest of input as chain of nodes
-                        if ~isempty(node_list)
-                            node_list(end).add_child(cur_input);
-                        else
-                            obj.root_nodes = [obj.root_nodes, cur_input];
-                        end
+                        
+                        cur_input = Node.empty;
                     end
                 end
             end
 
             % add continuation indices to node_list
             for k = 1:length(node_list)
-                node_list(k).add_contin(cur_input.contin_list(1));
+                node_list(k).add_contin(root_input.contin_list(1));
             end
         end
         
+        function [] = draw_tree(obj)
+            space = '    ';
+            note_space = '   ';
+            slash = '|';
+            back_slash = '\';
+            
+            nodes = obj.root_nodes;
+            children = [];
+            
+            % draw root nodes
+            str_roots = '';
+            for i=1:size(nodes, 2) 
+                cur_root = nodes(i);
+                str_roots = strcat(str_roots,num2str(cur_root.note_value));
+                str_roots = strcat(str_roots,{note_space}); 
+                for d=1:size(cur_root.children, 2)
+                    if (d ~= 1) 
+                        str_roots = strcat(str_roots,{note_space}); 
+                    end
+                end 
+            end
+            disp(str_roots);
+            
+            str_lines = '';
+            str_nodes = '';
+            
+            while (~isempty(nodes))
+                for index = 1:size(nodes, 2)
+                    cur_node = nodes(index);
+
+                    % draw lines between children and cur_node
+                    for l=1:size(cur_node.children,2)
+                        if (l == 1)
+                            str_lines = strcat(str_lines, slash);
+                        else
+                            str_lines = strcat(str_lines, back_slash);
+                        end
+
+                        str_lines = strcat(str_lines, {space}); 
+                        
+                        for d=1:size(cur_node.children(l).children, 2)
+                            if (d ~= 1) 
+                                str_lines = strcat(str_lines,{space}); 
+                            end
+                        end 
+                    end
+
+                    % draw children
+                    for c=1:size(cur_node.children, 2)
+                        cur_child = cur_node.children(c);
+                        str_nodes = strcat(str_nodes, num2str(cur_child.note_value));
+                        str_nodes = strcat(str_nodes, {note_space}); 
+                        children = [children, cur_child];
+                        for d=1:size(cur_child.children, 2)
+                            if (d ~= 1) 
+                                str_nodes = strcat(str_nodes,{note_space}); 
+                            end
+                        end 
+                    end
+
+                     if (isempty(cur_node.children))
+                        % no children, but add a space
+                        str_nodes = strcat(str_nodes, {note_space}); 
+                        str_lines = strcat(str_lines, {space}); 
+                    end
+
+                    if (index == size(nodes, 2))
+                        % Completed single row, move on to children
+                        nodes = children;
+                        children = [];
+                        disp(str_lines);
+                        disp(str_nodes);
+                        str_lines = '';
+                        str_nodes = '';
+                    end
+                end
+            end
+        end    
     end
-    
 end

--- a/test_script.m
+++ b/test_script.m
@@ -1,3 +1,4 @@
+clear;
 dummy_input_1 = [57 59 60 62];
 dummy_input_2 = [57 59 59 60];
 
@@ -6,3 +7,7 @@ test_tree = Prefix_tree;
 test_tree.parse(dummy_input_1)
 %%
 test_tree.parse(dummy_input_2)
+%%
+dummy_input_3 = [57 59 60 57];
+
+test_tree.parse(dummy_input_3);


### PR DESCRIPTION
- Fix bug where improper continuation lists are added to the tree.
- Clean up Prefix_tree.add_input() to avoid looping using children in while statement.
- Also adds beginnings of draw_tree() method for outputting the current tree as graphical text.